### PR TITLE
CAT-793: [SPIKE] Remove mandrill-api Gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     cognito (0.4.2)
       httparty (~> 0.18.1)
-      json (>= 1.8.6)
+      json (~> 2.5.1)
       json-jwt (~> 1.11.0, >= 1.11.0)
       rails (~> 5.1.6, >= 5.1.6.2)
 
@@ -67,7 +67,7 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
     json-jwt (1.11.0)
@@ -83,7 +83,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mini_mime (1.0.2)
+    mini_mime (1.0.3)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
     multi_xml (0.6.0)

--- a/cognito.gemspec
+++ b/cognito.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 5.1.6", ">= 5.1.6.2"
   s.add_dependency "httparty", '~> 0.18.1'
-  s.add_dependency "json", ">= 1.8.6"
+  s.add_dependency "json", "~> 2.5.1"
   s.add_dependency "json-jwt", "~> 1.11.0", ">= 1.11.0"
 
   s.add_development_dependency "pry"

--- a/cognito.gemspec
+++ b/cognito.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "rails", "~> 5.1.6", ">= 5.1.6.2"
-  s.add_dependency "httparty", '~> 0.18.1'
-  s.add_dependency "json", "~> 2.5.1"
+  s.add_dependency "httparty"
+  s.add_dependency "json"
   s.add_dependency "json-jwt", "~> 1.11.0", ">= 1.11.0"
 
   s.add_development_dependency "pry"

--- a/cognito.gemspec
+++ b/cognito.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 5.1.6", ">= 5.1.6.2"
   s.add_dependency "httparty"
-  s.add_dependency "json"
+  s.add_dependency "json", ">= 2.1"
   s.add_dependency "json-jwt", "~> 1.11.0", ">= 1.11.0"
 
   s.add_development_dependency "pry"

--- a/lib/cognito/version.rb
+++ b/lib/cognito/version.rb
@@ -1,3 +1,3 @@
 module Cognito
-  VERSION = '0.4.3'.freeze
+  VERSION = '0.4.4'.freeze
 end

--- a/lib/cognito/version.rb
+++ b/lib/cognito/version.rb
@@ -1,3 +1,3 @@
 module Cognito
-  VERSION = '0.4.2'.freeze
+  VERSION = '0.4.3'.freeze
 end


### PR DESCRIPTION
Linked issue: [CAT-793](https://vehiculum.atlassian.net/browse/CAT-793?atlOrigin=eyJpIjoiZjkwZTFhMWZhNDczNDNlZGI1ZTExMjdhMDY4NDNiYWIiLCJwIjoiaiJ9)
This is a complementary PR for CAT-793, it updates dependencies in order to avoid dependency conflicts with our main platform.